### PR TITLE
Fixing excessively broad patches to prevent errors on TweakScale.

### DIFF
--- a/GameData/RetroFuture/RetroFuture/Patches/RF_TweakScale.cfg
+++ b/GameData/RetroFuture/RetroFuture/Patches/RF_TweakScale.cfg
@@ -1,41 +1,61 @@
- @PART[*Cone*]:FOR[RetroFuture]:NEEDS[TweakScale]
- {
-     MODULE
-     {
-        name = TweakScale
+// Aero
+@PART[1mSharpCone]:FOR[RetroFuture]:NEEDS[TweakScale]
+{
+	 MODULE
+	{
+		name = TweakScale
 		type = free
-     }
- }
- 
-  @PART[*Intake*]:FOR[RetroFuture]:NEEDS[TweakScale]
- {
-     MODULE
-     {
-        name = TweakScale
+	}
+}
+
+@PART[rF*Intake]:FOR[RetroFuture]:NEEDS[TweakScale]
+{
+	MODULE
+	{
+		name = TweakScale
 		type = free
-     }
- }
+	}
+}
+
+@PART[noseConeLong]:FOR[RetroFuture]:NEEDS[TweakScale]
+{
+	 MODULE
+	{
+		name = TweakScale
+		type = free
+	}
+}
+
+@PART[rectNoseIntake]:FOR[RetroFuture]:NEEDS[TweakScale]
+{
+	 MODULE
+	{
+		name = TweakScale
+		type = free
+	}
+}
+
+@PART[rectIntake]:FOR[RetroFuture]:NEEDS[TweakScale]
+{
+	 MODULE
+	{
+		name = TweakScale
+		type = free
+	}
+}
+
+@PART[rectWingBase]:FOR[RetroFuture]:NEEDS[TweakScale]
+{
+	MODULE
+	{
+		name = TweakScale
+		type = free
+	}
+}
 
 
-  @PART[rectWingBase]:FOR[RetroFuture]:NEEDS[TweakScale]
- {
-     MODULE
-     {
-        name = TweakScale
-		type = free
-     }
- }
- 
- @PART[*Gear]:FOR[RetroFuture]:NEEDS[TweakScale]
- {
-     MODULE
-     {
-        name = TweakScale
-		type = free
-     }
- }
+// Utility
 
- 
 @PART[surfPortJr]:FOR[RetroFuture]:NEEDS[TweakScale]
 {
 	MODULE


### PR DESCRIPTION
Hi. I found a somewhat serious glitch on TweakScale last week, and I managed to tail it to RetroFuture (that one from SpaceDock). Checking in your fork, I confirmed that the faulty patches are still there, so I fixed them.

I didn't added any new feature, neither changed the present ones - what you get now is exactly the same you got before, but without mangling with others Add'Ons parts (including Squad!).

On a personal note, the current patches should be using the currently available presets, and a lot of parts could be supported too - but that is up you to decide.

More information can be found here: https://github.com/net-lisias-ksp/TweakScale/issues/21#issuecomment-477959078

Regards,
L.